### PR TITLE
Added GemJoin8 and GUSD example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ Note: `dss-gem-joins` is not reflective of supported Collateral Types on the mai
 |LINK|GemJoin|
 |BAL|GemJoin|
 |YFI|GemJoin|
+|GUSD|GemJoin8|

--- a/src/join-8.sol
+++ b/src/join-8.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/// join-8.sol -- Non-standard token adapters
+
+// Copyright (C) 2018 Rain <rainbreak@riseup.net>
+// Copyright (C) 2018-2020 Maker Ecosystem Growth Holdings, INC.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity >=0.5.12;
+
+import "dss/lib.sol";
+
+interface VatLike {
+    function slip(bytes32, address, int256) external;
+}
+
+interface GemLike {
+    function decimals() external view returns (uint8);
+    function transfer(address,uint256) external returns (bool);
+    function transferFrom(address,address,uint256) external returns (bool);
+    function erc20Impl() external view returns (address);
+}
+
+// GemJoin8
+// For a token that has a lower precision than 18, has decimals and it is upgradable (like GUSD)
+
+contract GemJoin8 is LibNote {
+    // --- Auth ---
+    mapping (address => uint256) public wards;
+    function rely(address usr) external note auth { wards[usr] = 1; }
+    function deny(address usr) external note auth { wards[usr] = 0; }
+    modifier auth { require(wards[msg.sender] == 1); _; }
+
+    VatLike  public vat;
+    bytes32  public ilk;
+    GemLike public gem;
+    bytes    public funcSig;
+    uint256  public dec;
+    uint256  public live;  // Access Flag
+
+    mapping (address => uint256) public implementations;
+
+    // implFunc_ is a no-argument view that returns a single address which points to the current implementation
+    constructor(address vat_, bytes32 ilk_, address gem_, string memory implFunc_) public {
+        gem = GemLike(gem_);
+        dec = gem.decimals();
+        require(dec < 18, "GemJoin8/decimals-18-or-higher");
+        wards[msg.sender] = 1;
+        live = 1;
+        vat = VatLike(vat_);
+        ilk = ilk_;
+        funcSig = abi.encodeWithSignature(implFunc_);
+        getImplementation();  // Test implementation call is valid
+    }
+
+    function cage() external note auth {
+        live = 0;
+    }
+
+    function setImplementation(address implementation, uint256 permitted) public auth note {
+        implementations[implementation] = permitted;  // 1 live, 0 disable
+    }
+
+    function getImplementation() internal returns (address) {
+        (bool success, bytes memory returnValue) = address(gem).call(funcSig);
+        require(success, "GemJoin8/invalid-function");
+        return abi.decode(returnValue, (address));
+    }
+
+    function mul(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        require(y == 0 || (z = x * y) / y == x, "GemJoin8/overflow");
+    }
+
+    function join(address urn, uint256 wad) public note {
+        require(live == 1, "GemJoin8/not-live");
+        uint256 wad18 = mul(wad, 10 ** (18 - dec));
+        require(int256(wad18) >= 0, "GemJoin8/overflow");
+        require(implementations[getImplementation()] == 1, "GemJoin8/implementation-invalid");
+        vat.slip(ilk, urn, int256(wad18));
+        require(gem.transferFrom(msg.sender, address(this), wad), "GemJoin8/failed-transfer");
+    }
+
+    function exit(address guy, uint256 wad) public note {
+        uint256 wad18 = mul(wad, 10 ** (18 - dec));
+        require(int256(wad18) >= 0, "GemJoin8/overflow");
+        require(implementations[getImplementation()] == 1, "GemJoin8/implementation-invalid");
+        vat.slip(ilk, msg.sender, -int256(wad18));
+        require(gem.transfer(guy, wad), "GemJoin8/failed-transfer");
+    }
+}

--- a/src/join-8.sol
+++ b/src/join-8.sol
@@ -51,7 +51,6 @@ contract GemJoin8 is LibNote {
 
     mapping (address => uint256) public implementations;
 
-    // implFunc_ is a no-argument view that returns a single address which points to the current implementation
     constructor(address vat_, bytes32 ilk_, address gem_) public {
         gem = GemLike(gem_);
         dec = gem.decimals();

--- a/src/join-8.sol
+++ b/src/join-8.sol
@@ -45,7 +45,7 @@ contract GemJoin8 is LibNote {
 
     VatLike  public vat;
     bytes32  public ilk;
-    GemLike public gem;
+    GemLike  public gem;
     uint256  public dec;
     uint256  public live;  // Access Flag
 

--- a/src/join.t.sol
+++ b/src/join.t.sol
@@ -447,7 +447,7 @@ contract DssDeployTest is DssDeployTestBase {
         assertEq(vat.gem("YFI", address(this)), 6 ether);
     }
 
-    function testGemJoin_GUSD() public {
+    function testGemJoin8_GUSD() public {
         deployKeepAuth();
         DSValue pip = new DSValue();
 
@@ -458,7 +458,7 @@ contract DssDeployTest is DssDeployTestBase {
 
         dssDeploy.deployCollateral("GUSD", address(gusdJoin), address(pip));
 
-        gusd.approve(address(gusdJoin), uint(-1));
+        gusd.approve(address(gusdJoin), uint256(-1));
         assertEq(gusd.balanceOf(address(this)), 100 * 10 ** 2);
         assertEq(gusd.balanceOf(address(gusdJoin)), 0);
         assertEq(vat.gem("GUSD", address(this)), 0);
@@ -585,7 +585,7 @@ contract DssDeployTest is DssDeployTestBase {
         GUSD gusd = new GUSD(100 * 10 ** 2);
         GemJoin8 gusdJoin = new GemJoin8(address(vat), "GUSD", address(gusd));
         dssDeploy.deployCollateral("GUSD", address(gusdJoin), address(pip));
-        gusd.approve(address(gusdJoin), uint(-1));
+        gusd.approve(address(gusdJoin), uint256(-1));
         // Fail here
         gusdJoin.join(address(this), 10 ether);
     }
@@ -596,7 +596,7 @@ contract DssDeployTest is DssDeployTestBase {
         GUSD gusd = new GUSD(100 * 10 ** 2);
         GemJoin8 gusdJoin = new GemJoin8(address(vat), "GUSD", address(gusd));
         dssDeploy.deployCollateral("GUSD", address(gusdJoin), address(pip));
-        gusd.approve(address(gusdJoin), uint(-1));
+        gusd.approve(address(gusdJoin), uint256(-1));
         gusdJoin.join(address(this), 10 * 10 ** 2);
         // Fail here
         gusdJoin.exit(address(this), 10 ether);
@@ -608,7 +608,7 @@ contract DssDeployTest is DssDeployTestBase {
         GUSD gusd = new GUSD(100 * 10 ** 2);
         GemJoin8 gusdJoin = new GemJoin8(address(vat), "GUSD", address(gusd));
         dssDeploy.deployCollateral("GUSD", address(gusdJoin), address(pip));
-        gusd.approve(address(gusdJoin), uint(-1));
+        gusd.approve(address(gusdJoin), uint256(-1));
         assertEq(gusd.balanceOf(address(this)), 100 * 10 ** 2);
         assertEq(gusd.balanceOf(address(gusdJoin)), 0);
         assertEq(vat.gem("GUSD", address(this)), 0);
@@ -623,7 +623,7 @@ contract DssDeployTest is DssDeployTestBase {
         GUSD gusd = new GUSD(100 * 10 ** 2);
         GemJoin8 gusdJoin = new GemJoin8(address(vat), "GUSD", address(gusd));
         dssDeploy.deployCollateral("GUSD", address(gusdJoin), address(pip));
-        gusd.approve(address(gusdJoin), uint(-1));
+        gusd.approve(address(gusdJoin), uint256(-1));
         gusdJoin.join(address(this), 10 * 10 ** 2);
         gusd.setImplementation(address(1));
         // Fail here
@@ -731,7 +731,7 @@ contract DssDeployTest is DssDeployTestBase {
 
         dssDeploy.deployCollateral("GUSD", address(gusdJoin), address(pip));
 
-        gusd.approve(address(gusdJoin), uint(-1));
+        gusd.approve(address(gusdJoin), uint256(-1));
         gusdJoin.join(address(this), 10);
         gusdJoin.cage();
         gusdJoin.join(address(this), 10);

--- a/src/join.t.sol
+++ b/src/join.t.sol
@@ -404,7 +404,7 @@ contract DssDeployTest is DssDeployTestBase {
         DSValue pip = new DSValue();
 
         GUSD gusd = new GUSD(100 * 10 ** 2);
-        GemJoin8 gusdJoin = new GemJoin8(address(vat), "GUSD", address(gusd), "erc20Impl()");
+        GemJoin8 gusdJoin = new GemJoin8(address(vat), "GUSD", address(gusd));
         gusdJoin.setImplementation(address(gusd), 1);
         assertEq(gusdJoin.dec(), 2);
 
@@ -535,7 +535,7 @@ contract DssDeployTest is DssDeployTestBase {
         deployKeepAuth();
         DSValue pip = new DSValue();
         GUSD gusd = new GUSD(100 * 10 ** 2);
-        GemJoin8 gusdJoin = new GemJoin8(address(vat), "GUSD", address(gusd), "erc20Impl()");
+        GemJoin8 gusdJoin = new GemJoin8(address(vat), "GUSD", address(gusd));
         dssDeploy.deployCollateral("GUSD", address(gusdJoin), address(pip));
         gusd.approve(address(gusdJoin), uint(-1));
         // Fail here
@@ -546,7 +546,7 @@ contract DssDeployTest is DssDeployTestBase {
         deployKeepAuth();
         DSValue pip = new DSValue();
         GUSD gusd = new GUSD(100 * 10 ** 2);
-        GemJoin8 gusdJoin = new GemJoin8(address(vat), "GUSD", address(gusd), "erc20Impl()");
+        GemJoin8 gusdJoin = new GemJoin8(address(vat), "GUSD", address(gusd));
         dssDeploy.deployCollateral("GUSD", address(gusdJoin), address(pip));
         gusd.approve(address(gusdJoin), uint(-1));
         gusdJoin.join(address(this), 10 * 10 ** 2);
@@ -558,7 +558,7 @@ contract DssDeployTest is DssDeployTestBase {
         deployKeepAuth();
         DSValue pip = new DSValue();
         GUSD gusd = new GUSD(100 * 10 ** 2);
-        GemJoin8 gusdJoin = new GemJoin8(address(vat), "GUSD", address(gusd), "erc20Impl()");
+        GemJoin8 gusdJoin = new GemJoin8(address(vat), "GUSD", address(gusd));
         dssDeploy.deployCollateral("GUSD", address(gusdJoin), address(pip));
         gusd.approve(address(gusdJoin), uint(-1));
         assertEq(gusd.balanceOf(address(this)), 100 * 10 ** 2);
@@ -573,21 +573,13 @@ contract DssDeployTest is DssDeployTestBase {
         deployKeepAuth();
         DSValue pip = new DSValue();
         GUSD gusd = new GUSD(100 * 10 ** 2);
-        GemJoin8 gusdJoin = new GemJoin8(address(vat), "GUSD", address(gusd), "erc20Impl()");
+        GemJoin8 gusdJoin = new GemJoin8(address(vat), "GUSD", address(gusd));
         dssDeploy.deployCollateral("GUSD", address(gusdJoin), address(pip));
         gusd.approve(address(gusdJoin), uint(-1));
         gusdJoin.join(address(this), 10 * 10 ** 2);
         gusd.setImplementation(address(1));
         // Fail here
         gusdJoin.exit(address(this), 10 * 10 ** 2);
-    }
-
-    function testFailGemJoin8BadFunctionSignature() public {
-        deployKeepAuth();
-        DSValue pip = new DSValue();
-        GUSD gusd = new GUSD(100 * 10 ** 2);
-        // Fail here
-        new GemJoin8(address(vat), "GUSD", address(gusd), "erc20Impl2()");
     }
 
     function testFailJoinAfterCageGemJoin2() public {
@@ -687,7 +679,7 @@ contract DssDeployTest is DssDeployTestBase {
         DSValue pip = new DSValue();
 
         GUSD gusd = new GUSD(100 * 10 ** 2);
-        GemJoin8 gusdJoin = new GemJoin8(address(vat), "GUSD", address(gusd), "erc20Impl()");
+        GemJoin8 gusdJoin = new GemJoin8(address(vat), "GUSD", address(gusd));
 
         dssDeploy.deployCollateral("GUSD", address(gusdJoin), address(pip));
 

--- a/src/tokens/GUSD.sol
+++ b/src/tokens/GUSD.sol
@@ -1,0 +1,70 @@
+pragma solidity >=0.5.12;
+
+contract GUSD {
+    function add(uint x, uint y) internal pure returns (uint z) {
+        require((z = x + y) >= x, "ds-math-add-overflow");
+    }
+    function sub(uint x, uint y) internal pure returns (uint z) {
+        require((z = x - y) <= x, "ds-math-sub-underflow");
+    }
+    event Approval(address indexed src, address indexed guy, uint wad);
+    event Transfer(address indexed src, address indexed dst, uint wad);
+
+    string  public  name = "GUSD";
+    string  public  symbol = "GUSD";
+    uint8   public  decimals = 2;
+    address public  erc20Impl;
+    uint256                                            _supply;
+    mapping (address => uint256)                       _balances;
+    mapping (address => mapping (address => uint256))  _approvals;
+
+    constructor(uint supply) public {
+        _balances[msg.sender] = supply;
+        _supply = supply;
+        setImplementation(address(this));
+    }
+
+    function setImplementation(address newImplementation) public {
+        erc20Impl = newImplementation;
+    }
+
+    function totalSupply() public view returns (uint) {
+        return _supply;
+    }
+    function balanceOf(address src) public view returns (uint) {
+        return _balances[src];
+    }
+    function allowance(address src, address guy) public view returns (uint) {
+        return _approvals[src][guy];
+    }
+
+    function transfer(address dst, uint wad) public returns (bool) {
+        return transferFrom(msg.sender, dst, wad);
+    }
+
+    function transferFrom(address src, address dst, uint wad)
+        public
+        returns (bool)
+    {
+        if (src != msg.sender) {
+            require(_approvals[src][msg.sender] >= wad, "insufficient-approval");
+            _approvals[src][msg.sender] = sub(_approvals[src][msg.sender], wad);
+        }
+
+        require(_balances[src] >= wad, "insufficient-balance");
+        _balances[src] = sub(_balances[src], wad);
+        _balances[dst] = add(_balances[dst], wad);
+
+        emit Transfer(src, dst, wad);
+
+        return true;
+    }
+
+    function approve(address guy, uint wad) public returns (bool) {
+        _approvals[msg.sender][guy] = wad;
+
+        emit Approval(msg.sender, guy, wad);
+
+        return true;
+    }
+}


### PR DESCRIPTION
Same code adapted from here: https://github.com/makerdao/dss-deploy/pull/56

Added GemJoin8 to support GUSD. To improve on re-usability for proxy contracts, I've allowed for arbitrary function names which return the current implementation.