### PR TITLE
Add UNI Collateral with GemJoin

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,4 @@ Note: `dss-gem-joins` is not reflective of supported Collateral Types on the mai
 |BAL|GemJoin|
 |YFI|GemJoin|
 |GUSD|GemJoin8|
+|UNI|GemJoin|

--- a/src/join.t.sol
+++ b/src/join.t.sol
@@ -25,6 +25,7 @@ import "./tokens/OMG.sol";
 import "./tokens/PAXUSD.sol";
 import "./tokens/REP.sol";
 import "./tokens/TUSD.sol";
+import "./tokens/UNI.sol";
 import "./tokens/USDC.sol";
 import "./tokens/USDT.sol";
 import "./tokens/WBTC.sol";
@@ -353,6 +354,29 @@ contract DssDeployTest is DssDeployTestBase {
         assertEq(comp.balanceOf(address(this)), 94 ether);
         assertEq(comp.balanceOf(address(compJoin)), 6 ether);
         assertEq(vat.gem("COMP", address(this)), 6 ether);
+    }
+
+        function testGemJoin_UNI() public {
+        deployKeepAuth();
+        DSValue pip = new DSValue();
+
+        UNI uni = new UNI(100 ether);
+        GemJoin uniJoin = new GemJoin(address(vat), "UNI", address(uni));
+        assertEq(uniJoin.dec(), 18);
+
+        dssDeploy.deployCollateral("UNI", address(uniJoin), address(pip));
+
+        uni.approve(address(uniJoin), uint256(-1));
+        assertEq(uni.balanceOf(address(this)), 100 ether);
+        assertEq(uni.balanceOf(address(uniJoin)), 0);
+        assertEq(vat.gem("UNI", address(this)), 0);
+        uniJoin.join(address(this), 10 ether);
+        assertEq(uni.balanceOf(address(uniJoin)), 10 ether);
+        assertEq(vat.gem("UNI", address(this)), 10 ether);
+        uniJoin.exit(address(this), 4 ether);
+        assertEq(uni.balanceOf(address(this)), 94 ether);
+        assertEq(uni.balanceOf(address(uniJoin)), 6 ether);
+        assertEq(vat.gem("UNI", address(this)), 6 ether);
     }
 
     function testGemJoin_LRC() public {

--- a/src/tokens/UNI.sol
+++ b/src/tokens/UNI.sol
@@ -1,0 +1,64 @@
+pragma solidity >=0.5.12;
+
+contract UNI {
+    function add(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        require((z = x + y) >= x, "ds-math-add-overflow");
+    }
+    function sub(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        require((z = x - y) <= x, "ds-math-sub-underflow");
+    }
+    event Approval(address indexed src, address indexed guy, uint256 wad);
+    event Transfer(address indexed src, address indexed dst, uint256 wad);
+
+    string  public  name = "Uniswap";
+    string  public  symbol = "UNI";
+    uint8   public  decimals = 18;
+    uint256                                            _supply;
+    mapping (address => uint256)                       _balances;
+    mapping (address => mapping (address => uint256))  _approvals;
+
+    constructor(uint256 supply) public {
+        _balances[msg.sender] = supply;
+        _supply = supply;
+    }
+
+    function totalSupply() public view returns (uint256) {
+        return _supply;
+    }
+    function balanceOf(address src) public view returns (uint256) {
+        return _balances[src];
+    }
+    function allowance(address src, address guy) public view returns (uint256) {
+        return _approvals[src][guy];
+    }
+
+    function transfer(address dst, uint256 wad) public returns (bool) {
+        return transferFrom(msg.sender, dst, wad);
+    }
+
+    function transferFrom(address src, address dst, uint256 wad)
+        public
+        returns (bool)
+    {
+        if (src != msg.sender) {
+            require(_approvals[src][msg.sender] >= wad, "insufficient-approval");
+            _approvals[src][msg.sender] = sub(_approvals[src][msg.sender], wad);
+        }
+
+        require(_balances[src] >= wad, "insufficient-balance");
+        _balances[src] = sub(_balances[src], wad);
+        _balances[dst] = add(_balances[dst], wad);
+
+        emit Transfer(src, dst, wad);
+
+        return true;
+    }
+
+    function approve(address guy, uint256 wad) public returns (bool) {
+        _approvals[msg.sender][guy] = wad;
+
+        emit Approval(msg.sender, guy, wad);
+
+        return true;
+    }
+}


### PR DESCRIPTION
# Description

Collateral Type (e.g. `ETH-A`): UNI-A

COB Team Name or Author(s): @naszam

GemJoin Adapter: GemJoin

Is this GemJoin adapter new? : No

If so, why is a new one needed? : N/A


# Contribution Checklist

- [x] Collateral token contract has been added in `src/tokens/` as `TOKEN.sol`, if not already present
- [x] If needed, a new `GemJoin` has been added in `src/` as `join-X.sol`
- [x] A new test (`testGemJoinX_TOKEN()`) has been added to `src/join.t.sol` and follows previous tests as examples
- [x] If needed, other tests have been added to verify functionality of the new `GemJoin`:
    - [x] `testFailGemJoinXJoinWad()`
    - [x] `testFailGemJoinXExitWad()`
    - [x] `testFailGemJoinXJoin()`
    - [x] `testFailGemJoinXExit()`
    - [x] `testFailJoinAfterCageGemJoinX()`
- [x] README has been updated to reflect a new token and `GemJoin` addition

# Checklist

- [x] Confirm that token contract matches the verified source on etherscan mainnet
- [x] If a new `GemJoin` is added, ensure the above description is accurate
- [x] If a new `GemJoin` is added, ensure a new `GemJoin` has been added with the correct name
- [x] Ensure README is updated
- [x] Manually review the new test(s)
- [x] Manually run dapp tests in `src/join.t.sol` to confirm they all pass
