### PR TITLE
Add PermissionedGemJoin

### DIFF
--- a/src/join-permissioned.sol
+++ b/src/join-permissioned.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/// join-permissioned.sol -- Non-standard token adapters
+
+// Copyright (C) 2021 Dai Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity >=0.5.12;
+
+import "dss/lib.sol";
+
+interface VatLike {
+    function slip(bytes32, address, int256) external;
+}
+
+interface GemLike {
+    function decimals() external view returns (uint256);
+    function transfer(address, uint256) external returns (bool);
+    function transferFrom(address, address, uint256) external returns (bool);
+}
+
+// For a token that needs to limit who can join collateral, without giving full ward authorization.
+
+contract PermissionedGemJoin is LibNote {
+    VatLike public vat;
+    bytes32 public ilk;
+    GemLike public gem;
+    uint256 public dec;
+    uint256 public live;  // Access Flag
+
+    // --- Auth ---
+    mapping (address => uint256) public wards;
+    function rely(address usr) public note auth { wards[usr] = 1; }
+    function deny(address usr) public note auth { wards[usr] = 0; }
+    modifier auth { require(wards[msg.sender] == 1, "PermissionedGemJoin/non-authed"); _; }
+
+    // Whitelisted contracts, set by an auth
+    mapping (address => uint256) public bud;
+
+    modifier toll { require(bud[msg.sender] == 1, "PermissionedGemJoin/contract-not-whitelisted"); _; }
+
+    constructor(address vat_, bytes32 ilk_, address gem_) public {
+        wards[msg.sender] = 1;
+        live = 1;
+        vat = VatLike(vat_);
+        ilk = ilk_;
+        gem = GemLike(gem_);
+        dec = gem.decimals();
+    }
+
+    function cage() external note auth {
+        live = 0;
+    }
+
+    function join(address usr, uint256 wad) public toll note {
+        require(live == 1, "PermissionedGemJoin/not-live");
+        require(int256(wad) >= 0, "PermissionedGemJoin/overflow");
+        vat.slip(ilk, usr, int256(wad));
+        require(gem.transferFrom(msg.sender, address(this), wad), "PermissionedGemJoin/failed-transfer");
+    }
+
+    function exit(address usr, uint256 wad) public note {
+        require(wad <= 2 ** 255, "PermissionedGemJoin/overflow");
+        vat.slip(ilk, msg.sender, -int256(wad));
+        require(gem.transfer(usr, wad), "PermissionedGemJoin/failed-transfer");
+    }
+
+    function kiss(address a) external note auth {
+        require(a != address(0), "PermissionedGemJoin/no-contract-0");
+        bud[a] = 1;
+    }
+
+    function diss(address a) external note auth {
+        bud[a] = 0;
+    }
+}

--- a/src/join.t.sol
+++ b/src/join.t.sol
@@ -10,6 +10,7 @@ import {GemJoin6} from "./join-6.sol";
 import {GemJoin7} from "./join-7.sol";
 import {GemJoin8} from "./join-8.sol";
 import {AuthGemJoin} from "./join-auth.sol";
+import {PermissionedGemJoin} from "./join-permissioned.sol";
 
 import "./tokens/AAVE.sol";
 import "./tokens/BAL.sol";
@@ -750,7 +751,8 @@ contract DssDeployTest is DssDeployTestBase {
 
     function testFailJoinAfterCageGemJoin5() public {
         deployKeepAuth();
-        DSValue pip = new DSValue();
+        DSValue pip = new DSValue();// For a token that needs restriction on the sources which are able to execute the join function (like SAI through Migration contract)
+
 
         USDC usdc = new USDC(100 ether);
         GemJoin5 usdcJoin = new GemJoin5(address(vat), "USDC", address(usdc));
@@ -860,5 +862,66 @@ contract DssDeployTest is DssDeployTestBase {
         sai.approve(address(saiJoin), uint256(-1));
         saiJoin.deny(address(this));
         saiJoin.join(address(this), 10);
+    }
+
+    function testFailJoinAfterCagePermissionedGemJoin() public {
+        deployKeepAuth();
+        DSValue pip = new DSValue();
+
+        DSToken wbtc = new DSToken("WBTC");
+        wbtc.mint(20);
+        PermissionedGemJoin wbtcJoin = new PermissionedGemJoin(address(vat), "WBTC", address(wbtc));
+
+        dssDeploy.deployCollateral("WBTC", address(wbtcJoin), address(pip));
+
+        wbtc.approve(address(wbtcJoin), uint256(-1));
+        wbtcJoin.join(address(this), 10);
+        wbtcJoin.cage();
+        wbtcJoin.join(address(this), 10);
+    }
+
+    function testJoinPermissionedGemJoin() public {
+        deployKeepAuth();
+        DSValue pip = new DSValue();
+
+        DSToken wbtc = new DSToken("WBTC");
+        wbtc.mint(20);
+        PermissionedGemJoin wbtcJoin = new PermissionedGemJoin(address(vat), "WBTC", address(wbtc));
+
+        dssDeploy.deployCollateral("WBTC", address(wbtcJoin), address(pip));
+
+        wbtc.approve(address(wbtcJoin), uint256(-1));
+        wbtcJoin.kiss(address(this));
+        wbtcJoin.join(address(this), 10);
+    }
+
+    function testFailJoinPermissionedGemJoinNotAllowed() public {
+        deployKeepAuth();
+        DSValue pip = new DSValue();
+
+        DSToken wbtc = new DSToken("WBTC");
+        wbtc.mint(20);
+        PermissionedGemJoin wbtcJoin = new PermissionedGemJoin(address(vat), "WBTC", address(wbtc));
+
+        dssDeploy.deployCollateral("WBTC", address(wbtcJoin), address(pip));
+
+        wbtc.approve(address(wbtcJoin), uint256(-1));
+        wbtcJoin.join(address(this), 10);
+    }
+
+    function testFailJoinPermissionedGemJoinDissed() public {
+        deployKeepAuth();
+        DSValue pip = new DSValue();
+
+        DSToken wbtc = new DSToken("WBTC");
+        wbtc.mint(20);
+        PermissionedGemJoin wbtcJoin = new PermissionedGemJoin(address(vat), "WBTC", address(wbtc));
+
+        dssDeploy.deployCollateral("WBTC", address(wbtcJoin), address(pip));
+
+        wbtc.approve(address(wbtcJoin), uint256(-1));
+        wbtcJoin.kiss(address(this));
+        wbtcJoin.diss(address(this));
+        wbtcJoin.join(address(this), 10);
     }
 }


### PR DESCRIPTION
# Description

Collateral Type (e.g. `ETH-A`): Standard ERC20

COB Team Name or Author(s): Protocol Engineering

GemJoin Adapter: PermissionedGemJoin

Is this GemJoin adapter new? : Yes

If so, why is a new one needed? : Allow authorized users to interact with a join adapter without granting full `auth` access (i.e. to `cage` and `rely` other addresses)


# Contribution Checklist

- [ X ] Collateral token contract has been added in `src/tokens/` as `TOKEN.sol`, if not already present
- [ X ] If needed, a new `GemJoin` has been added in `src/` as `join-X.sol`
- [ X ] A new test (`testGemJoinX_TOKEN()`) has been added to `src/join.t.sol` and follows previous tests as examples
- [ ] If needed, other tests have been added to verify functionality of the new `GemJoin`:
    - [ ] `testFailGemJoinXJoinWad()`
    - [ ] `testFailGemJoinXExitWad()`
    - [ ] `testFailGemJoinXJoin()`
    - [ ] `testFailGemJoinXExit()`
    - [ ] `testFailJoinAfterCageGemJoinX()`
- [ ] README has been updated to reflect a new token and `GemJoin` addition

# Checklist

- [ ] Confirm that token contract matches the verified source on etherscan mainnet
- [ ] If a new `GemJoin` is added, ensure the above description is accurate
- [ ] If a new `GemJoin` is added, ensure a new `GemJoin` has been added with the correct name
- [ ] Ensure README is updated
- [ ] Manually review the new test(s)
- [ ] Manually run dapp tests in `src/join.t.sol` to confirm they all pass
