### PR TITLE
Internalize overloaded exit logic

### DIFF
--- a/src/join-managed.sol
+++ b/src/join-managed.sol
@@ -90,11 +90,15 @@ contract ManagedGemJoin {
         emit Join(usr, amt);
     }
 
-    function exit(address usr, uint256 amt) external {
-        exit(usr, msg.sender, amt);
+    function exit(address usr, uint256 amt) external auth {
+        _exit(usr, msg.sender, amt);
     }
 
-    function exit(address usr, address dst, uint256 amt) public auth {
+    function exit(address usr, address dst, uint256 amt) external auth {
+        _exit(usr, dst, amt);
+    }
+
+    function _exit(address usr, address dst, uint256 amt) internal {
         uint256 wad = _mul(amt, 10 ** (18 - dec));
         require(wad <= 2 ** 255, "ManagedGemJoin/overflow");
         vat.slip(ilk, usr, -int256(wad));


### PR DESCRIPTION
Uses an internal function for exit logic so that overloaded exits can remain external.