### PR TITLE
`GemJoin9`: More changes

### DIFF
--- a/src/join-9.sol
+++ b/src/join-9.sol
@@ -121,14 +121,14 @@ contract GemJoin9 {
 
         uint256 _total = total;     // Cache to save an SLOAD
         wad = _sub(gem.balanceOf(address(this)), _total);
-        require(wad <= MAXINT256, "GemJoin9/overflow");
+        require(wad <= MAXINT256, "GemJoin9/int256-overflow");
 
         total = _add(_total, wad);
         vat.slip(ilk, usr, int256(wad));
     }
 
     function exit(address usr, uint256 wad) external {
-        require(wad <= MAXINT256, "GemJoin9/overflow");
+        require(wad <= MAXINT256, "GemJoin9/int256-overflow");
 
         total = _sub(total, wad);
         vat.slip(ilk, msg.sender, -int256(wad));

--- a/src/join-9.sol
+++ b/src/join-9.sol
@@ -20,7 +20,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity >=0.6.12;
+pragma solidity ^0.6.12;
 
 interface VatLike {
     function slip(bytes32, address, int256) external;

--- a/src/join-9.sol
+++ b/src/join-9.sol
@@ -58,7 +58,11 @@ contract GemJoin9 {
         vat = VatLike(vat_);
         ilk = ilk_;
         gem = GemLike(gem_);
-        dec = GemLike(gem_).decimals();
+
+        uint256 dec_ = GemLike(gem_).decimals();
+        require(dec_ <= 18, "GemJoin9/decimals-19-or-higher");
+        dec = dec_;
+
         live = 1;
         wards[msg.sender] = 1;
         emit Rely(msg.sender);

--- a/src/join-9.sol
+++ b/src/join-9.sol
@@ -86,6 +86,8 @@ contract GemJoin9 {
     }
 
     // --- Math ---
+    uint256 internal constant MAXINT256 = uint256(type(int256).max);
+
     function _add(uint256 x, uint256 y) internal pure returns (uint256 z) {
         require((z = x + y) >= x, "GemJoin9/overflow");
     }
@@ -115,14 +117,14 @@ contract GemJoin9 {
 
         uint256 _total = total;     // Cache to save an SLOAD
         wad = _sub(gem.balanceOf(address(this)), _total);
-        require(int256(wad) >= 0, "GemJoin9/overflow");
+        require(wad <= MAXINT256, "GemJoin9/overflow");
 
         total = _add(_total, wad);
         vat.slip(ilk, usr, int256(wad));
     }
 
     function exit(address usr, uint256 wad) external {
-        require(wad <= 2 ** 255, "GemJoin9/overflow");
+        require(wad <= MAXINT256, "GemJoin9/overflow");
 
         total = _sub(total, wad);
         vat.slip(ilk, msg.sender, -int256(wad));

--- a/src/join-9.sol
+++ b/src/join-9.sol
@@ -107,9 +107,9 @@ contract GemJoin9 {
     function join(address usr, uint256 wad) external {
         require(gem.transferFrom(msg.sender, address(this), wad), "GemJoin9/failed-transfer");
 
-        _join(usr);
+        uint256 _wad = _join(usr);
 
-        emit Join(usr, wad);
+        emit Join(usr, _wad);
     }
 
     function _join(address usr) internal returns (uint256 wad) {

--- a/src/join-9.sol
+++ b/src/join-9.sol
@@ -1,9 +1,11 @@
+// SPDX-FileCopyrightText: © 2018 Rain <rainbreak@riseup.net>
+// SPDX-FileCopyrightText: © 2020 Dai Foundation <www.daifoundation.org>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 /// join-9.sol -- Non-standard token adapters
 
 // Copyright (C) 2018 Rain <rainbreak@riseup.net>
-// Copyright (C) 2020-2022 Dai Foundation
+// Copyright (C) 2020 Dai Foundation <www.daifoundation.org>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/join-9.sol
+++ b/src/join-9.sol
@@ -18,7 +18,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity ^0.6.12;
+pragma solidity >=0.6.12;
 
 interface VatLike {
     function slip(bytes32, address, int256) external;

--- a/src/join-9.sol
+++ b/src/join-9.sol
@@ -88,8 +88,6 @@ contract GemJoin9 {
     }
 
     // --- Math ---
-    uint256 internal constant MAXINT256 = uint256(type(int256).max);
-
     function _add(uint256 x, uint256 y) internal pure returns (uint256 z) {
         require((z = x + y) >= x, "GemJoin9/overflow");
     }
@@ -119,14 +117,14 @@ contract GemJoin9 {
 
         uint256 _total = total;     // Cache to save an SLOAD
         wad = _sub(gem.balanceOf(address(this)), _total);
-        require(wad <= MAXINT256, "GemJoin9/int256-overflow");
+        require(int256(wad) >= 0, "GemJoin9/int256-overflow");
 
         total = _add(_total, wad);
         vat.slip(ilk, usr, int256(wad));
     }
 
     function exit(address usr, uint256 wad) external {
-        require(wad <= MAXINT256, "GemJoin9/int256-overflow");
+        require(wad <= 2 ** 255, "GemJoin9/int256-overflow");
 
         total = _sub(total, wad);
         vat.slip(ilk, msg.sender, -int256(wad));

--- a/src/join-9.sol
+++ b/src/join-9.sol
@@ -58,7 +58,7 @@ contract GemJoin9 {
         gem = GemLike(gem_);
 
         uint256 dec_ = GemLike(gem_).decimals();
-        require(dec_ <= 18, "GemJoin9/decimals-19-or-higher");
+        require(dec_ == 18, "GemJoin9/invalid-decimals");
         dec = dec_;
 
         live = 1;

--- a/src/join-9.sol
+++ b/src/join-9.sol
@@ -1,12 +1,10 @@
 // SPDX-FileCopyrightText: © 2018 Rain <rainbreak@riseup.net>
 // SPDX-FileCopyrightText: © 2020 Dai Foundation <www.daifoundation.org>
+//
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 /// join-9.sol -- Non-standard token adapters
 
-// Copyright (C) 2018 Rain <rainbreak@riseup.net>
-// Copyright (C) 2020 Dai Foundation <www.daifoundation.org>
-//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/src/join-9.sol
+++ b/src/join-9.sol
@@ -109,9 +109,9 @@ contract GemJoin9 {
     function join(address usr, uint256 wad) external {
         require(gem.transferFrom(msg.sender, address(this), wad), "GemJoin9/failed-transfer");
 
-        uint256 _wad = _join(usr);
+        _join(usr);
 
-        emit Join(usr, _wad);
+        emit Join(usr, wad);
     }
 
     function _join(address usr) internal returns (uint256 wad) {


### PR DESCRIPTION
- [x]  Add [FileCopyRigthText](https://github.com/daifoundation/docs/blob/master/COPYRIGHT-GUIDANCE.md)
- [x] CS-5.1 (emit joined `wad` amount, net of transfer fees)
- [x] CS-6.4 (include decimal check in the constructor, following `join-managed` pattern)
- [x] Consider CS-6.3 #35 
